### PR TITLE
[Feature] Navigation & EntryList 

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import {Tabs} from './src/config/router.js';
 import Main from './src/components/Main.js';
 
 import {
@@ -11,8 +12,8 @@ import {
 export default class MindFit extends Component {
   render() {
     return (
-      <View>
-        <Main />
+      <View style={styles.container}>
+        <Tabs />
       </View>
     );
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react": "16.0.0-alpha.6",
     "react-native": "0.43.3",
     "react-native-vector-icons": "^4.0.1",
+    "react-navigation": "^1.0.0-beta.8"
   },
   "devDependencies": {
     "babel-jest": "19.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "axios": "^0.16.1",
     "react": "16.0.0-alpha.6",
     "react-native": "0.43.3",
-    "react-native-vector-icons": "^4.0.1"
+    "react-native-vector-icons": "^4.0.1",
   },
   "devDependencies": {
     "babel-jest": "19.0.0",

--- a/src/components/Calls.js
+++ b/src/components/Calls.js
@@ -1,0 +1,23 @@
+'use strict';
+
+import React, { Component } from 'react';
+
+import {
+  StyleSheet,
+  View,
+} from 'react-native';
+
+class Calls extends Component {
+  render() {
+    return (
+      <View />
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+
+});
+
+
+export default Calls;

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,0 +1,31 @@
+'use strict';
+
+import React from 'react';
+
+import {
+  StyleSheet,
+  View,
+} from 'react-native';
+
+const Card = ({children, height}) => {
+  
+  const renderCardHeight = (height) => {
+    return {
+    height: height,
+    marginBottom: 10,
+    paddingLeft: 14,
+    paddingRight: 14,
+    shadowColor: '#000',
+    shadowOffset: {width: 0, height: 2},
+    shadowOpacity: 0.1,
+    }
+  }
+
+  return(
+    <View style={renderCardHeight(height)}>
+      {children}
+    </View>
+  );
+}
+
+export default Card;

--- a/src/components/EntryDetail.js
+++ b/src/components/EntryDetail.js
@@ -1,0 +1,43 @@
+'use strict';
+
+import React, { Component } from 'react';
+import Card from './Card';
+
+import {
+  StyleSheet,
+  View,
+  Text,
+} from 'react-native';
+
+class EntryView extends Component {
+
+  render() {
+    const {created_at, entry_type, text, video, watson_results} = this.props.navigation.state.params;
+    console.log('===this', this);
+    console.log('===entry_type', entry_type);
+    return (
+      <View style={styles.entryDetailContainer}>
+        <Card height={200}>
+          <Text style={styles.text}>{text}</Text>
+        </Card> 
+      </View>
+
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  entryDetailContainer: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  text: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: '#262626',
+    marginTop: 10,
+  }
+});
+
+
+export default EntryView;

--- a/src/components/EntryList.js
+++ b/src/components/EntryList.js
@@ -20,6 +20,7 @@ export default class EntryList extends Component {
     };
 
     this.renderEntryList = this.renderEntryList.bind(this);
+    this.entryPress = this.entryPress.bind(this);
   }
 
   componentWillMount() {
@@ -42,9 +43,15 @@ export default class EntryList extends Component {
     return this.state.entries.map( (entry, index) => 
       <TouchableOpacity
         key={index} 
+        onPress={() => this.entryPress(entry)}
+      >
         <EntryTextDisplay entry={entry} />
       </TouchableOpacity>
     );
+  }
+
+  entryPress(entry) {
+    this.props.navigation.navigate('EntryDetail', entry);
   }
 
   render() {

--- a/src/components/EntryList.js
+++ b/src/components/EntryList.js
@@ -8,7 +8,8 @@ import {
   StyleSheet,
   View,
   Text,
-  ScrollView
+  ScrollView,
+  TouchableOpacity
 } from 'react-native';
 
 export default class EntryList extends Component {
@@ -20,6 +21,7 @@ export default class EntryList extends Component {
 
     this.renderEntryList = this.renderEntryList.bind(this);
   }
+
   componentWillMount() {
     const data = {
       user_id: '58f55a76393538d31aad168e'
@@ -38,7 +40,10 @@ export default class EntryList extends Component {
 
   renderEntryList() {
     return this.state.entries.map( (entry, index) => 
-      <EntryTextDisplay key={index} entry={entry}/>
+      <TouchableOpacity
+        key={index} 
+        <EntryTextDisplay entry={entry} />
+      </TouchableOpacity>
     );
   }
 
@@ -55,9 +60,10 @@ export default class EntryList extends Component {
 
 const styles = StyleSheet.create({
   entryListContainer: {
-    
+    flex: 1,
+    backgroundColor: '#fff',
   }, 
   text: {
-    color: 'black'
+    color: '#262626',
   }
 });

--- a/src/components/EntryTextDisplay.js
+++ b/src/components/EntryTextDisplay.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Icon from 'react-native-vector-icons/MaterialIcons';
+import Card from './Card';
 
 import {
   StyleSheet,
@@ -12,15 +13,15 @@ import {
 const EntryTextDisplay = ({entry}) => {
     const renderIcon = (entryType) => {
       const icon = {
-        video: (<Icon name="videocam" size={24} color="#EB5424" />),
-        audio: (<Icon name="keyboard-voice" size={24} color="#EB5424" />),
-        text: (<Icon name="text-fields" size={24} color="#EB5424" />)
+        video: 'videocam', 
+        audio: 'keyboard-voice',
+        text: 'text-fields'
       }
-      return icon[entryType];
+      return  <Icon name={icon[entryType]} size={24} color="#EB5424" />
     }
 
     return (
-      <View style={styles.card}>
+      <Card height={120}>
         <View style={styles.entryContainer}>
           <View style={styles.entryMeta}>
             <Text style={styles.date}>{entry.created_at.slice(0, 10)}</Text>
@@ -32,26 +33,16 @@ const EntryTextDisplay = ({entry}) => {
           ellipsizeMode={'tail'}
           >{entry.text}</Text>
         </View>
-      </View>
+      </Card>
     )
 }
 
 const styles = StyleSheet.create({
-  card: {
-    // backgroundColor: 'red',
-    height: 120,
-    marginBottom: 10,
-    shadowColor: '#000',
-    shadowOffset: {width: 0, height: 2},
-    shadowOpacity: 0.1,
-  },
   entryContainer: {
     flex: 1,
-    marginRight: 14,
-    marginLeft: 14,
   },
   entryMeta: {
-    flex: 1,
+    flex: 2,
     flexDirection: 'row',
     justifyContent: 'flex-start',
     alignItems: 'center',
@@ -64,12 +55,13 @@ const styles = StyleSheet.create({
     color: '#82888a'
   },
   text: {
-    flex: 3,
+    flex: 5,
     justifyContent: 'center',
     alignItems: 'center',
     color: '#292929',
-    fontSize: 18,
-    marginTop: 10,
+    fontSize: 16,
+    lineHeight: 24,
+    marginTop: 6,
   }
 });
 

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -13,7 +13,6 @@ export default class Main extends Component {
   render() {
     return (
       <View>
-        <Header headerText={'Main'}/>
         <EntryList />
       </View>
     )

--- a/src/components/NewEntry.js
+++ b/src/components/NewEntry.js
@@ -1,0 +1,26 @@
+import React, { Component } from 'react';
+import TextEntry from './TextEntry';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TextInput,
+  Button
+} from 'react-native';
+
+export default class NewEntry extends Component {
+  render() {
+    return (
+      <View style={styles.textEntryContainer}>
+        <TextEntry />
+      </View>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  textEntryContainer: {
+    flex: 1,
+    backgroundColor: '#fff'
+  }, 
+});

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -1,0 +1,23 @@
+'use strict';
+
+import React, { Component } from 'react';
+
+import {
+  StyleSheet,
+  View,
+} from 'react-native';
+
+class Profile extends Component {
+  render() {
+    return (
+      <View />
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+
+});
+
+
+export default Profile;

--- a/src/components/Results.js
+++ b/src/components/Results.js
@@ -1,0 +1,23 @@
+'use strict';
+
+import React, { Component } from 'react';
+
+import {
+  StyleSheet,
+  View,
+} from 'react-native';
+
+class Results extends Component {
+  render() {
+    return (
+      <View />
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+
+});
+
+
+export default Results;

--- a/src/components/TextEntry.js
+++ b/src/components/TextEntry.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TextInput,
+  Button
+} from 'react-native';
+
+export default class TextEntry extends Component {
+  render() {
+    return (
+      <View style={styles.textEntryContainer}>
+        <View style={styles.textBox}>
+          <TextInput
+            placeholder="hello world"
+            multiline={true}
+            style={styles.textInput}
+          />
+        </View>
+      </View>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  textEntryContainer: {
+    flex: 1,
+    backgroundColor: '#fff',
+  }, 
+  textInput: {
+    height: 400,
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+    padding: 10,
+    borderColor: 'gray', 
+    borderWidth: 1,
+    fontSize: 16,
+  }
+});

--- a/src/config/router.js
+++ b/src/config/router.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { TabNavigator, StackNavigator } from 'react-navigation';
+import Icon from 'react-native-vector-icons/MaterialIcons';
+
+import EntryList from '../components/EntryList';
+import NewEntry from '../components/NewEntry';
+import EntryDetail from '../components/EntryDetail';
+import Profile from '../components/Profile';
+import Results from '../components/Results';
+import Calls from '../components/Calls';
+
+export const EntryStack = StackNavigator({
+  EntryList: {
+    screen: EntryList,
+    navigationOptions: {
+      title: 'All Entries',
+    },
+  },
+  EntryDetail: {
+    screen: EntryDetail,
+    navigationOptions: ({navigation}) => ({
+      title: `${navigation.state.params.created_at.slice(0, 10)}`,
+    }),
+  },
+});
+
+export const NewEntryStack = StackNavigator({
+   NewEntry: {
+    screen:  NewEntry,
+    navigationOptions: {
+      title: ' New Entry',
+    },
+  },
+});
+
+export const Tabs = TabNavigator({
+  EntryList: {
+    screen: EntryStack,
+    navigationOptions: {
+      tabBarLabel: 'Entry',
+      tabBarIcon: ({ tintColor }) => (
+        <Icon name="book" size={24} color={tintColor} />
+      ),
+    },
+  },
+  Calls: {
+    screen: Calls,
+    navigationOptions: {
+      tabBarLabel: 'Calls',
+      tabBarIcon: ({ tintColor }) => (
+        <Icon name="call" size={24} color={tintColor} />
+      ),
+    },
+  },  
+  NewEntry: {
+    screen: NewEntryStack,
+    navigationOptions: {
+      tabBarLabel: 'New Entry',
+      tabBarIcon: ({ tintColor }) => (
+        <Icon name="add" size={24} color={tintColor} />
+      ),
+    },
+  },  
+  Results: {
+    screen: Results,
+    navigationOptions: {
+      tabBarLabel: 'Results',
+      tabBarIcon: ({ tintColor }) => (
+        <Icon name="insert-chart" size={24} color={tintColor} />
+      ),
+    },
+  },
+  Profile: {
+    screen: Profile,
+    navigationOptions: {
+      tabBarLabel: 'Profile',
+      tabBarIcon: ({ tintColor }) => (
+        <Icon name="account-circle" size={24} color={tintColor} />
+      ),
+    },
+  },
+}, {
+  tabBarOptions: {
+    activeTintColor: '#EB5424',
+  },
+});


### PR DESCRIPTION
====Navigation====
- setup tabNav to access 'entry', 'calls', 'new entry', 'results', 'profile'
- setup stackNav for 'entries'
- connect entryList with entryDetail via react-navigation
<img width="376" alt="screen shot 2017-04-20 at 11 48 32 am" src="https://cloud.githubusercontent.com/assets/12800136/25247447/aa32c35a-25bf-11e7-886d-cbcceef71b75.png">

====Entries====
- add icons to showcase entry type
- add TouchableOpacity when user touches a specific entry
- create entryDetail that shows all text 

<img width="372" alt="screen shot 2017-04-20 at 11 51 00 am" src="https://cloud.githubusercontent.com/assets/12800136/25247443/a8f2f67c-25bf-11e7-85db-6bb963949f3b.png">
